### PR TITLE
:bug: Implementando severidade de aviso no teste para nome da cidade tabela cidades

### DIFF
--- a/models/marts_analytics/dimensions/dim_cidades.yml
+++ b/models/marts_analytics/dimensions/dim_cidades.yml
@@ -21,7 +21,9 @@ models:
           contains_pii: true
         data_type: string
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: warn
 
       - name: estado_id
         data_type: int

--- a/models/staging/sources.yml
+++ b/models/staging/sources.yml
@@ -24,7 +24,9 @@ sources:
           - name: cidade
             description: '{{ doc("nome_cidade") }}'
             tests:
-              - not_null
+              - not_null:
+                  config:
+                    severity: warn
 
           - name: id_estados
             description: '{{ doc("estado_id") }}'

--- a/models/staging/stg_cidades.yml
+++ b/models/staging/stg_cidades.yml
@@ -19,7 +19,9 @@ models:
         description: '{{ doc("nome_cidade") }}'
         data_type: string
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: warn
 
       - name: estado_id
         data_type: int


### PR DESCRIPTION
 **Contexto**
Identificamos que a coluna cidade da tabela cidades pode conter valores nulos.
Em conversa com o DBA o ajuste já está sendo realizado na aplicação front-end e precisamos implementar teste com severidade de aviso (warn) na coluna cidade da tabela cidades

- [x] Implementar Severidade de Aviso